### PR TITLE
Fix the build on OS X

### DIFF
--- a/src/lzma-stream-asynccode.cpp
+++ b/src/lzma-stream-asynccode.cpp
@@ -46,6 +46,7 @@ namespace {
 #define pipeErrno GetLastError
 #else
 #include <unistd.h>
+#include <cerrno>
 
 namespace {
 	typedef int pipe_t;


### PR DESCRIPTION
Since a7726c299acd66607e2eeca43c9f404aa05c8e62 `errno.h` is no more included in `lzma-stream-asynccode.cpp` when compiling on OS X (it is apparently a dependency of `<string>` on Linux systems).
