### PR TITLE
Performance problem with small chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,11 @@ Stream.prototype.syncStream = function(options) {
 		}
 	};
 	
+	ret.prototype._writev = function(chunks, callback) {
+		chunks = chunks.map(function (chunk) { return chunk.chunk; });
+		this._write(Buffer.concat(chunks), null, callback);
+	};
+
 	ret.prototype._flush = function(callback) {
 		this._transform(null, null, callback);
 	};


### PR DESCRIPTION
Writing many small (and similar) chunks takes an enormeous amount of time, far longer than processing all the data in one big chunk.  This should not be the case.

In this branch I'm exposing the bug in a test case as a first step towards a solution.  I don't know yet what a proper solution to this issue should look like.  Haven't found my way around the native code yet.  So this merge request here is currently more like a bug report ticket, but since I think the test cases may be useful in addressing this, I'm posting it as a merge request.