### PR TITLE
Update node-pre-gyp to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lzma-native",
-  "version": "4.0.2",
+  "version": "4.0.1",
   "engines": {
     "node": ">=6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lzma-native",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "engines": {
     "node": ">=6.0.0"
   },
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "nan": "^2.10.0",
-    "node-pre-gyp": "^0.10.3",
+    "node-pre-gyp": "^0.11.0",
     "readable-stream": "^2.3.5",
     "rimraf": "^2.6.1"
   },


### PR DESCRIPTION
fix #67

Build successful on Linux with node versions: 6.14.4, 8.12.0, 10.12.0 and 11.0.0.

Build forced by setting invalid `binary.host` in package.json ( + `rm -Rf ~ /.node-gyp` ).

`npm i phantomjs-prebuilt https://github.com/webcarrot/lzma-native.git#patch-1` also work.
