### PR TITLE
fix compatibility with Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TRAVIS_NODE_VERSION="10"
   - TRAVIS_NODE_VERSION="11"
   - TRAVIS_NODE_VERSION="12"
+  - TRAVIS_NODE_VERSION="13"
 os:
   - linux
   - osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@
 environment:
   fast_finish: true
   matrix:
+    - nodejs_version: "13"
     - nodejs_version: "12"
     - nodejs_version: "11"
     - nodejs_version: "10"

--- a/src/index-parser.cpp
+++ b/src/index-parser.cpp
@@ -440,7 +440,7 @@ void IndexParser::Init(Local<Object> exports) {
   Nan::SetPrototypeMethod(tpl, "parse", Parse);
   
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
-  exports->Set(NewString("IndexParser"), Nan::New<Function>(constructor));
+  Nan::Set(exports, NewString("IndexParser"), Nan::New<Function>(constructor));
 }
 
 NAN_METHOD(IndexParser::New) {

--- a/src/lzma-stream.cpp
+++ b/src/lzma-stream.cpp
@@ -353,7 +353,7 @@ void LZMAStream::Init(Local<Object> exports) {
   Nan::SetPrototypeMethod(tpl, "aloneDecoder_", AloneDecoder);
   
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
-  exports->Set(NewString("Stream"), Nan::New<Function>(constructor));
+  Nan::Set(exports, NewString("Stream"), Nan::New<Function>(constructor));
 }
 
 NAN_METHOD(LZMAStream::New) {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -6,92 +6,92 @@ void moduleInit(Local<Object> exports) {
   LZMAStream::Init(exports);
   IndexParser::Init(exports);
   
-  exports->Set(NewString("versionNumber"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaVersionNumber)).ToLocalChecked());
-  exports->Set(NewString("versionString"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaVersionString)).ToLocalChecked());
-  exports->Set(NewString("checkIsSupported"),         Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCheckIsSupported)).ToLocalChecked());
-  exports->Set(NewString("checkSize"),                Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCheckSize)).ToLocalChecked());
-  exports->Set(NewString("crc32_"),                   Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCRC32)).ToLocalChecked());
-  exports->Set(NewString("filterEncoderIsSupported"), Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaFilterEncoderIsSupported)).ToLocalChecked());
-  exports->Set(NewString("filterDecoderIsSupported"), Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaFilterDecoderIsSupported)).ToLocalChecked());
-  exports->Set(NewString("rawEncoderMemusage"),       Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaRawEncoderMemusage)).ToLocalChecked());
-  exports->Set(NewString("rawDecoderMemusage"),       Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaRawDecoderMemusage)).ToLocalChecked());
-  exports->Set(NewString("mfIsSupported"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaMfIsSupported)).ToLocalChecked());
-  exports->Set(NewString("modeIsSupported"),          Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaModeIsSupported)).ToLocalChecked());
-  exports->Set(NewString("easyEncoderMemusage"),      Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaEasyEncoderMemusage)).ToLocalChecked());
-  exports->Set(NewString("easyDecoderMemusage"),      Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaEasyDecoderMemusage)).ToLocalChecked());
+  Nan::Set(exports, NewString("versionNumber"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaVersionNumber)).ToLocalChecked());
+  Nan::Set(exports, NewString("versionString"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaVersionString)).ToLocalChecked());
+  Nan::Set(exports, NewString("checkIsSupported"),         Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCheckIsSupported)).ToLocalChecked());
+  Nan::Set(exports, NewString("checkSize"),                Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCheckSize)).ToLocalChecked());
+  Nan::Set(exports, NewString("crc32_"),                   Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaCRC32)).ToLocalChecked());
+  Nan::Set(exports, NewString("filterEncoderIsSupported"), Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaFilterEncoderIsSupported)).ToLocalChecked());
+  Nan::Set(exports, NewString("filterDecoderIsSupported"), Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaFilterDecoderIsSupported)).ToLocalChecked());
+  Nan::Set(exports, NewString("rawEncoderMemusage"),       Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaRawEncoderMemusage)).ToLocalChecked());
+  Nan::Set(exports, NewString("rawDecoderMemusage"),       Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaRawDecoderMemusage)).ToLocalChecked());
+  Nan::Set(exports, NewString("mfIsSupported"),            Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaMfIsSupported)).ToLocalChecked());
+  Nan::Set(exports, NewString("modeIsSupported"),          Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaModeIsSupported)).ToLocalChecked());
+  Nan::Set(exports, NewString("easyEncoderMemusage"),      Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaEasyEncoderMemusage)).ToLocalChecked());
+  Nan::Set(exports, NewString("easyDecoderMemusage"),      Nan::GetFunction(Nan::New<FunctionTemplate>(lzmaEasyDecoderMemusage)).ToLocalChecked());
   
   // enum lzma_ret
-  exports->Set(NewString("OK"),                Nan::New<Number>(LZMA_OK));
-  exports->Set(NewString("STREAM_END"),        Nan::New<Number>(LZMA_STREAM_END));
-  exports->Set(NewString("NO_CHECK"),          Nan::New<Number>(LZMA_NO_CHECK));
-  exports->Set(NewString("UNSUPPORTED_CHECK"), Nan::New<Number>(LZMA_UNSUPPORTED_CHECK));
-  exports->Set(NewString("GET_CHECK"),         Nan::New<Number>(LZMA_GET_CHECK));
-  exports->Set(NewString("MEM_ERROR"),         Nan::New<Number>(LZMA_MEM_ERROR));
-  exports->Set(NewString("MEMLIMIT_ERROR"),    Nan::New<Number>(LZMA_MEMLIMIT_ERROR));
-  exports->Set(NewString("FORMAT_ERROR"),      Nan::New<Number>(LZMA_FORMAT_ERROR));
-  exports->Set(NewString("OPTIONS_ERROR"),     Nan::New<Number>(LZMA_OPTIONS_ERROR));
-  exports->Set(NewString("DATA_ERROR"),        Nan::New<Number>(LZMA_DATA_ERROR));
-  exports->Set(NewString("BUF_ERROR"),         Nan::New<Number>(LZMA_BUF_ERROR));
-  exports->Set(NewString("PROG_ERROR"),        Nan::New<Number>(LZMA_PROG_ERROR));
+  Nan::Set(exports, NewString("OK"),                Nan::New<Number>(LZMA_OK));
+  Nan::Set(exports, NewString("STREAM_END"),        Nan::New<Number>(LZMA_STREAM_END));
+  Nan::Set(exports, NewString("NO_CHECK"),          Nan::New<Number>(LZMA_NO_CHECK));
+  Nan::Set(exports, NewString("UNSUPPORTED_CHECK"), Nan::New<Number>(LZMA_UNSUPPORTED_CHECK));
+  Nan::Set(exports, NewString("GET_CHECK"),         Nan::New<Number>(LZMA_GET_CHECK));
+  Nan::Set(exports, NewString("MEM_ERROR"),         Nan::New<Number>(LZMA_MEM_ERROR));
+  Nan::Set(exports, NewString("MEMLIMIT_ERROR"),    Nan::New<Number>(LZMA_MEMLIMIT_ERROR));
+  Nan::Set(exports, NewString("FORMAT_ERROR"),      Nan::New<Number>(LZMA_FORMAT_ERROR));
+  Nan::Set(exports, NewString("OPTIONS_ERROR"),     Nan::New<Number>(LZMA_OPTIONS_ERROR));
+  Nan::Set(exports, NewString("DATA_ERROR"),        Nan::New<Number>(LZMA_DATA_ERROR));
+  Nan::Set(exports, NewString("BUF_ERROR"),         Nan::New<Number>(LZMA_BUF_ERROR));
+  Nan::Set(exports, NewString("PROG_ERROR"),        Nan::New<Number>(LZMA_PROG_ERROR));
   
   // enum lzma_action
-  exports->Set(NewString("RUN"),        Nan::New<Number>(LZMA_RUN));
-  exports->Set(NewString("SYNC_FLUSH"), Nan::New<Number>(LZMA_SYNC_FLUSH));
-  exports->Set(NewString("FULL_FLUSH"), Nan::New<Number>(LZMA_FULL_FLUSH));
-  exports->Set(NewString("FINISH"),     Nan::New<Number>(LZMA_FINISH));
+  Nan::Set(exports, NewString("RUN"),        Nan::New<Number>(LZMA_RUN));
+  Nan::Set(exports, NewString("SYNC_FLUSH"), Nan::New<Number>(LZMA_SYNC_FLUSH));
+  Nan::Set(exports, NewString("FULL_FLUSH"), Nan::New<Number>(LZMA_FULL_FLUSH));
+  Nan::Set(exports, NewString("FINISH"),     Nan::New<Number>(LZMA_FINISH));
   
   // enum lzma_check
-  exports->Set(NewString("CHECK_NONE"),   Nan::New<Number>(LZMA_CHECK_NONE));
-  exports->Set(NewString("CHECK_CRC32"),  Nan::New<Number>(LZMA_CHECK_CRC32));
-  exports->Set(NewString("CHECK_CRC64"),  Nan::New<Number>(LZMA_CHECK_CRC64));
-  exports->Set(NewString("CHECK_SHA256"), Nan::New<Number>(LZMA_CHECK_SHA256));
+  Nan::Set(exports, NewString("CHECK_NONE"),   Nan::New<Number>(LZMA_CHECK_NONE));
+  Nan::Set(exports, NewString("CHECK_CRC32"),  Nan::New<Number>(LZMA_CHECK_CRC32));
+  Nan::Set(exports, NewString("CHECK_CRC64"),  Nan::New<Number>(LZMA_CHECK_CRC64));
+  Nan::Set(exports, NewString("CHECK_SHA256"), Nan::New<Number>(LZMA_CHECK_SHA256));
   
   // lzma_match_finder
-  exports->Set(NewString("MF_HC3"), Nan::New<Number>(LZMA_MF_HC3));
-  exports->Set(NewString("MF_HC4"), Nan::New<Number>(LZMA_MF_HC4));
-  exports->Set(NewString("MF_BT2"), Nan::New<Number>(LZMA_MF_BT2));
-  exports->Set(NewString("MF_BT3"), Nan::New<Number>(LZMA_MF_BT3));
-  exports->Set(NewString("MF_BT4"), Nan::New<Number>(LZMA_MF_BT4));
+  Nan::Set(exports, NewString("MF_HC3"), Nan::New<Number>(LZMA_MF_HC3));
+  Nan::Set(exports, NewString("MF_HC4"), Nan::New<Number>(LZMA_MF_HC4));
+  Nan::Set(exports, NewString("MF_BT2"), Nan::New<Number>(LZMA_MF_BT2));
+  Nan::Set(exports, NewString("MF_BT3"), Nan::New<Number>(LZMA_MF_BT3));
+  Nan::Set(exports, NewString("MF_BT4"), Nan::New<Number>(LZMA_MF_BT4));
   
   // lzma_mode
-  exports->Set(NewString("MODE_FAST"),   Nan::New<Number>(LZMA_MODE_FAST));
-  exports->Set(NewString("MODE_NORMAL"), Nan::New<Number>(LZMA_MODE_NORMAL));
+  Nan::Set(exports, NewString("MODE_FAST"),   Nan::New<Number>(LZMA_MODE_FAST));
+  Nan::Set(exports, NewString("MODE_NORMAL"), Nan::New<Number>(LZMA_MODE_NORMAL));
   
   // defines
-  exports->Set(NewString("FILTER_X86"),               NewString("LZMA_FILTER_X86"));
-  exports->Set(NewString("FILTER_POWERPC"),           NewString("LZMA_FILTER_POWERPC"));
-  exports->Set(NewString("FILTER_IA64"),              NewString("LZMA_FILTER_IA64"));
-  exports->Set(NewString("FILTER_ARM"),               NewString("LZMA_FILTER_ARM"));
-  exports->Set(NewString("FILTER_ARMTHUMB"),          NewString("LZMA_FILTER_ARMTHUMB"));
-  exports->Set(NewString("FILTER_SPARC"),             NewString("LZMA_FILTER_SPARC"));
-  exports->Set(NewString("FILTER_DELTA"),             NewString("LZMA_FILTER_DELTA"));
-  exports->Set(NewString("FILTERS_MAX"),              NewString("LZMA_FILTERS_MAX"));
-  exports->Set(NewString("FILTER_LZMA1"),             NewString("LZMA_FILTER_LZMA1"));
-  exports->Set(NewString("FILTER_LZMA2"),             NewString("LZMA_FILTER_LZMA2"));
-  exports->Set(NewString("VLI_UNKNOWN"),              NewString("LZMA_VLI_UNKNOWN"));
+  Nan::Set(exports, NewString("FILTER_X86"),               NewString("LZMA_FILTER_X86"));
+  Nan::Set(exports, NewString("FILTER_POWERPC"),           NewString("LZMA_FILTER_POWERPC"));
+  Nan::Set(exports, NewString("FILTER_IA64"),              NewString("LZMA_FILTER_IA64"));
+  Nan::Set(exports, NewString("FILTER_ARM"),               NewString("LZMA_FILTER_ARM"));
+  Nan::Set(exports, NewString("FILTER_ARMTHUMB"),          NewString("LZMA_FILTER_ARMTHUMB"));
+  Nan::Set(exports, NewString("FILTER_SPARC"),             NewString("LZMA_FILTER_SPARC"));
+  Nan::Set(exports, NewString("FILTER_DELTA"),             NewString("LZMA_FILTER_DELTA"));
+  Nan::Set(exports, NewString("FILTERS_MAX"),              NewString("LZMA_FILTERS_MAX"));
+  Nan::Set(exports, NewString("FILTER_LZMA1"),             NewString("LZMA_FILTER_LZMA1"));
+  Nan::Set(exports, NewString("FILTER_LZMA2"),             NewString("LZMA_FILTER_LZMA2"));
+  Nan::Set(exports, NewString("VLI_UNKNOWN"),              NewString("LZMA_VLI_UNKNOWN"));
   
-  exports->Set(NewString("VLI_BYTES_MAX"),            Nan::New<Number>(LZMA_VLI_BYTES_MAX));
-  exports->Set(NewString("CHECK_ID_MAX"),             Nan::New<Number>(LZMA_CHECK_ID_MAX));
-  exports->Set(NewString("CHECK_SIZE_MAX"),           Nan::New<Number>(LZMA_CHECK_SIZE_MAX));
-  exports->Set(NewString("PRESET_DEFAULT"),           Nan::New<Number>(LZMA_PRESET_DEFAULT));
-  exports->Set(NewString("PRESET_LEVEL_MASK"),        Nan::New<Number>(LZMA_PRESET_LEVEL_MASK));
-  exports->Set(NewString("PRESET_EXTREME"),           Nan::New<Number>(LZMA_PRESET_EXTREME));
-  exports->Set(NewString("TELL_NO_CHECK"),            Nan::New<Number>(LZMA_TELL_NO_CHECK));
-  exports->Set(NewString("TELL_UNSUPPORTED_CHECK"),   Nan::New<Number>(LZMA_TELL_UNSUPPORTED_CHECK));
-  exports->Set(NewString("TELL_ANY_CHECK"),           Nan::New<Number>(LZMA_TELL_ANY_CHECK));
-  exports->Set(NewString("CONCATENATED"),             Nan::New<Number>(LZMA_CONCATENATED));
-  exports->Set(NewString("STREAM_HEADER_SIZE"),       Nan::New<Number>(LZMA_STREAM_HEADER_SIZE));
-  exports->Set(NewString("VERSION_MAJOR"),            Nan::New<Number>(LZMA_VERSION_MAJOR));
-  exports->Set(NewString("VERSION_MINOR"),            Nan::New<Number>(LZMA_VERSION_MINOR));
-  exports->Set(NewString("VERSION_PATCH"),            Nan::New<Number>(LZMA_VERSION_PATCH));
-  exports->Set(NewString("VERSION_STABILITY"),        Nan::New<Number>(LZMA_VERSION_STABILITY));
-  exports->Set(NewString("VERSION_STABILITY_ALPHA"),  Nan::New<Number>(LZMA_VERSION_STABILITY_ALPHA));
-  exports->Set(NewString("VERSION_STABILITY_BETA"),   Nan::New<Number>(LZMA_VERSION_STABILITY_BETA));
-  exports->Set(NewString("VERSION_STABILITY_STABLE"), Nan::New<Number>(LZMA_VERSION_STABILITY_STABLE));
-  exports->Set(NewString("VERSION"),                  Nan::New<Number>(LZMA_VERSION));
-  exports->Set(NewString("VERSION_STRING"),           NewString(LZMA_VERSION_STRING));
+  Nan::Set(exports, NewString("VLI_BYTES_MAX"),            Nan::New<Number>(LZMA_VLI_BYTES_MAX));
+  Nan::Set(exports, NewString("CHECK_ID_MAX"),             Nan::New<Number>(LZMA_CHECK_ID_MAX));
+  Nan::Set(exports, NewString("CHECK_SIZE_MAX"),           Nan::New<Number>(LZMA_CHECK_SIZE_MAX));
+  Nan::Set(exports, NewString("PRESET_DEFAULT"),           Nan::New<Number>(LZMA_PRESET_DEFAULT));
+  Nan::Set(exports, NewString("PRESET_LEVEL_MASK"),        Nan::New<Number>(LZMA_PRESET_LEVEL_MASK));
+  Nan::Set(exports, NewString("PRESET_EXTREME"),           Nan::New<Number>(LZMA_PRESET_EXTREME));
+  Nan::Set(exports, NewString("TELL_NO_CHECK"),            Nan::New<Number>(LZMA_TELL_NO_CHECK));
+  Nan::Set(exports, NewString("TELL_UNSUPPORTED_CHECK"),   Nan::New<Number>(LZMA_TELL_UNSUPPORTED_CHECK));
+  Nan::Set(exports, NewString("TELL_ANY_CHECK"),           Nan::New<Number>(LZMA_TELL_ANY_CHECK));
+  Nan::Set(exports, NewString("CONCATENATED"),             Nan::New<Number>(LZMA_CONCATENATED));
+  Nan::Set(exports, NewString("STREAM_HEADER_SIZE"),       Nan::New<Number>(LZMA_STREAM_HEADER_SIZE));
+  Nan::Set(exports, NewString("VERSION_MAJOR"),            Nan::New<Number>(LZMA_VERSION_MAJOR));
+  Nan::Set(exports, NewString("VERSION_MINOR"),            Nan::New<Number>(LZMA_VERSION_MINOR));
+  Nan::Set(exports, NewString("VERSION_PATCH"),            Nan::New<Number>(LZMA_VERSION_PATCH));
+  Nan::Set(exports, NewString("VERSION_STABILITY"),        Nan::New<Number>(LZMA_VERSION_STABILITY));
+  Nan::Set(exports, NewString("VERSION_STABILITY_ALPHA"),  Nan::New<Number>(LZMA_VERSION_STABILITY_ALPHA));
+  Nan::Set(exports, NewString("VERSION_STABILITY_BETA"),   Nan::New<Number>(LZMA_VERSION_STABILITY_BETA));
+  Nan::Set(exports, NewString("VERSION_STABILITY_STABLE"), Nan::New<Number>(LZMA_VERSION_STABILITY_STABLE));
+  Nan::Set(exports, NewString("VERSION"),                  Nan::New<Number>(LZMA_VERSION));
+  Nan::Set(exports, NewString("VERSION_STRING"),           NewString(LZMA_VERSION_STRING));
   
-  exports->Set(NewString("asyncCodeAvailable"),       Nan::New<Boolean>(LZMAStream::asyncCodeAvailable));
+  Nan::Set(exports, NewString("asyncCodeAvailable"),       Nan::New<Boolean>(LZMAStream::asyncCodeAvailable));
 }
 
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -62,9 +62,9 @@ Local<Object> lzmaRetError(lzma_ret rv) {
     ++p;
   
   Local<Object> e = Local<Object>::Cast(Nan::Error(p->desc));
-  e->Set(NewString("code"), Nan::New<Integer>(rv));
-  e->Set(NewString("name"), NewString(p->name));
-  e->Set(NewString("desc"), NewString(p->desc));
+  Nan::Set(e, NewString("code"), Nan::New<Integer>(rv));
+  Nan::Set(e, NewString("name"), NewString(p->name));
+  Nan::Set(e, NewString("desc"), NewString(p->desc));
   
   return e;
 }


### PR DESCRIPTION
This PR should make `lzma-native` compatible with Node.js 13 by fixing compilation errors (due to recent V8 changes) like:

```
../src/index-parser.cpp:443:12: error: no matching member function for call to 'Set'
  exports->Set(NewString("IndexParser"), Nan::New<Function>(constructor));
  ~~~~~~~~~^~~
/Users/chrmoritz/Library/Caches/node-gyp/13.1.0/include/node/v8.h:3424:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
                                    ^
/Users/chrmoritz/Library/Caches/node-gyp/13.1.0/include/node/v8.h:3427:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
```

This also adds Node.js 13 to the CI ~~and removes the now EOL Node.js 11 from it~~.