### PR TITLE
build: fixed build for BSD-based OS addaleax/lzma-native#98

### DIFF
--- a/liblzma-build.sh
+++ b/liblzma-build.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  *bsd) alias make='gmake';;
+  *)
+esac
+
 cd "$1/liblzma"
 make
 make install


### PR DESCRIPTION
This code can be used to automatically build a port for a BSD based OS. Without the ugly workaround using a symbolic link.
A small step to automatically build a Joplin app from ports