### PR TITLE
build: fix build on Apple Silicon

### DIFF
--- a/liblzma-config.sh
+++ b/liblzma-config.sh
@@ -10,6 +10,14 @@ cd "$TARGET_DIR"
 tar xvjf "$SRC_TARBALL" >node_liblzma_config.log 2>&1 
 
 export CFLAGS="-fPIC $CFLAGS"
+
+# Fix build on Apple Silicon
+if [[ ("$OSTYPE" == "darwin"*) && ($(uname -m) == "arm64") ]]; then
+	XZ_SRC_DIR=$(ls | grep xz-*)
+	sed -i.bak 's/\tnone)/\tarm64-*)\n\t\tbasic_machine=$(echo $basic_machine | sed "s\/arm64\/aarch64\/")\n\t\t;;\n\t\tnone)/g' $XZ_SRC_DIR/build-aux/config.sub
+	rm $XZ_SRC_DIR/build-aux/config.sub.bak
+fi
+
 sh xz-*/configure --enable-static --disable-shared --disable-scripts --disable-lzmainfo \
 	--disable-lzma-links --disable-lzmadec --disable-xzdec --disable-xz --disable-rpath \
 	--prefix="$TARGET_DIR/build" CFLAGS="$CFLAGS" >>node_liblzma_config.log 2>&1 

--- a/liblzma-config.sh
+++ b/liblzma-config.sh
@@ -7,17 +7,16 @@ TARGET_DIR="$1/liblzma"
 mkdir -p "$TARGET_DIR"
 cd "$TARGET_DIR"
 
-tar xvjf "$SRC_TARBALL" >node_liblzma_config.log 2>&1 
+tar xvjf "$SRC_TARBALL" >node_liblzma_config.log 2>&1
 
 export CFLAGS="-fPIC $CFLAGS"
 
 # Fix build on Apple Silicon
 if [[ ("$OSTYPE" == "darwin"*) && ($(uname -m) == "arm64") ]]; then
-	XZ_SRC_DIR=$(ls | grep xz-*)
-	sed -i.bak 's/\tnone)/\tarm64-*)\n\t\tbasic_machine=$(echo $basic_machine | sed "s\/arm64\/aarch64\/")\n\t\t;;\n\t\tnone)/g' $XZ_SRC_DIR/build-aux/config.sub
-	rm $XZ_SRC_DIR/build-aux/config.sub.bak
+    XZ_SRC_DIR=$(ls | grep xz-*)
+    sed -i '' 's/\tnone)/\tarm64-*)\n\t\tbasic_machine=$(echo $basic_machine | sed "s\/arm64\/aarch64\/")\n\t\t;;\n\t\tnone)/g' $XZ_SRC_DIR/build-aux/config.sub
 fi
 
 sh xz-*/configure --enable-static --disable-shared --disable-scripts --disable-lzmainfo \
-	--disable-lzma-links --disable-lzmadec --disable-xzdec --disable-xz --disable-rpath \
-	--prefix="$TARGET_DIR/build" CFLAGS="$CFLAGS" >>node_liblzma_config.log 2>&1 
+    --disable-lzma-links --disable-lzmadec --disable-xzdec --disable-xz --disable-rpath \
+    --prefix="$TARGET_DIR/build" CFLAGS="$CFLAGS" >>node_liblzma_config.log 2>&1


### PR DESCRIPTION
Add `arm64` to `config.sub` to support build on Apple Silicon. diff like:

```diff
--- a/build-aux/config.sub
+++ b/build-aux/config.sub
@@ -1258,6 +1258,9 @@ case $basic_machine in
 		basic_machine=z80-unknown
 		os=-sim
 		;;
+	arm64-*)
+		basic_machine=$(echo $basic_machine | sed 's/arm64/aarch64/')
+		;;
 	none)
 		basic_machine=none-none
 		os=-none
```