### PR TITLE
attempt to fix windows prebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,24 +24,15 @@ jobs:
         uses: actions/setup-node@v2.3.0
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.6
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Windows Setup
         if: matrix.os == 'windows-latest'
-        run: yarn prepare-win32
+        run: npm run prepare-win32
       - name: Install
-        run: yarn
+        run: npm install
       - name: Lint
-        run: yarn jshint
+        run: npm run jshint
       - name: Test
-        run: yarn test
+        run: npm run test
 
   prebuild:
     needs: test
@@ -65,22 +56,13 @@ jobs:
         uses: actions/setup-node@v2.3.0
         with:
           node-version: 12.x
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.6
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.arch }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-yarn-
       - name: Windows Setup
         if: matrix.os == 'windows'
-        run: yarn prepare-win32
+        run: npm run prepare-win32
       - name: Install
-        run: yarn
+        run: npm install
       - name: Prebuild binaries
-        run: yarn prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false $([[ $OSTYPE != darwin* ]] && echo --llvm_version=0.0 || true)
+        run: npm run prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false $([[ $OSTYPE != darwin* ]] && echo --llvm_version=0.0 || true)
         shell: bash
         env:
           PREBUILD_ARCH: ${{ matrix.arch }}
@@ -104,17 +86,8 @@ jobs:
         with:
           node-version: 12.x
           registry-url: 'https://registry.npmjs.org'
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2.1.6
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.arch }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-yarn-
       - name: Install
-        run: yarn
+        run: npm install
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v2.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Install
         run: yarn
       - name: Prebuild binaries
-        run: yarn prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false
+        run: yarn prebuild --v8_enable_pointer_compression=false --v8_enable_31bit_smis_on_64bit_arch=false $([[ $OSTYPE != darwin* ]] && echo --llvm_version=0.0 || true)
+        shell: bash
         env:
           PREBUILD_ARCH: ${{ matrix.arch }}
       - name: Upload binaries as an artifact


### PR DESCRIPTION
##### Revert "Revert "ci: set llvm_version to 0.0 on non-macOS hosts for prebuilds""

This reverts commit 8c324b2672b1698848dd2fa00a7c201d1411a90f.

##### ci: use npm instead of yarn
