### PR TITLE
Fix build issue in liblzma

### DIFF
--- a/liblzma-config.sh
+++ b/liblzma-config.sh
@@ -11,10 +11,15 @@ tar xvjf "$SRC_TARBALL" >node_liblzma_config.log 2>&1
 
 export CFLAGS="-fPIC $CFLAGS"
 
+XZ_SRC_DIR=$(ls | grep xz-*)
+
 # Fix build on Apple Silicon
 if [ $(uname) = "Darwin" -a $(uname -m) = "arm64" ]; then
-    XZ_SRC_DIR=$(ls | grep xz-*)
     sed -i '' 's/\tnone)/\tarm64-*)\n\t\tbasic_machine=$(echo $basic_machine | sed "s\/arm64\/aarch64\/")\n\t\t;;\n\t\tnone)/g' $XZ_SRC_DIR/build-aux/config.sub
+fi
+
+if [ $(uname) = "Linux" ]; then
+    find $XZ_SRC_DIR -name config.guess -exec cp -f /usr/share/libtool/build-aux/config.guess {} \;
 fi
 
 sh xz-*/configure --enable-static --disable-shared --disable-scripts --disable-lzmainfo \


### PR DESCRIPTION
The config.guess file in libxz is too old. This lead to a problem that it doesn't support some new machine like RISC-V 64.

This patch override the libxz config.guess file with the latest one in the build system.
