### PR TITLE
Update dependencies to build on node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "lzmajs": "bin/lzmajs"
   },
   "dependencies": {
-    "node-addon-api": "^3.1.0",
-    "node-gyp-build": "^4.2.1",
-    "readable-stream": "^3.6.0"
+    "node-addon-api": "^8.5.0",
+    "node-gyp-build": "^4.8.4",
+    "readable-stream": "^4.7.0"
   },
   "keywords": [
     "lzma",
@@ -45,9 +45,9 @@
     "url": "https://github.com/addaleax/lzma-native/issues"
   },
   "devDependencies": {
-    "bl": "^4.1.0",
-    "jshint": "^2.12.0",
-    "mocha": "^8.3.1",
-    "prebuildify": "^5.0.0"
+    "bl": "^6.1.4",
+    "jshint": "^2.13.6",
+    "mocha": "^11.7.5",
+    "prebuildify": "^6.0.1"
   }
 }


### PR DESCRIPTION
This PR fixes errors when trying to build lzma-native using **Node 24**. This is the error we get when running `npm install`:

```
  COPY Release/nothing.a
  CXX(target) Release/obj.target/lzma_native/src/util.o
In file included from ../src/liblzma-node.hpp:8,
                 from ../src/util.cpp:1:
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2477:60: error: expected unqualified-id before ‘)’ token
 2477 |     TypedThreadSafeFunction<ContextType, DataType, CallJs>();
      |                                                            ^
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2479:33: error: expected ‘)’ before ‘tsFunctionValue’
 2479 |         napi_threadsafe_function tsFunctionValue);
      |                                 ^~~~~~~~~~~~~~~~
      |                                 )
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2478:59: note: to match this ‘(’
 2478 |     TypedThreadSafeFunction<ContextType, DataType, CallJs>(
      |                                                           ^
In file included from /home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2725:
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi-inl.h:4764:8: error: no declaration matches ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction()’
 4764 | inline TypedThreadSafeFunction<ContextType, DataType, CallJs>::
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi-inl.h:4764:8: note: no functions named ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction()’
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2347:9: note: ‘class Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>’ defined here
 2347 |   class TypedThreadSafeFunction {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi-inl.h:4771:8: error: no declaration matches ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction(napi_threadsafe_function)’
 4771 | inline TypedThreadSafeFunction<ContextType, DataType, CallJs>::
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi-inl.h:4771:8: note: no functions named ‘Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>::TypedThreadSafeFunction(napi_threadsafe_function)’
/home/ubuntu/sdprash/lzma-native/node_modules/node-addon-api/napi.h:2347:9: note: ‘class Napi::TypedThreadSafeFunction<ContextType, DataType, CallJs>’ defined here
 2347 |   class TypedThreadSafeFunction {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
make: *** [lzma_native.target.mk:121: Release/obj.target/lzma_native/src/util.o] Error 1
make: Leaving directory '/home/ubuntu/sdprash/lzma-native/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack at ChildProcess.<anonymous> (/home/ubuntu/.nvm/versions/node/v24.11.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
gyp ERR! System Linux 6.14.0-1015-aws
gyp ERR! command "/home/ubuntu/.nvm/versions/node/v24.11.0/bin/node" "/home/ubuntu/.nvm/versions/node/v24.11.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/ubuntu/sdprash/lzma-native
gyp ERR! node -v v24.11.0
gyp ERR! node-gyp -v v11.4.2
gyp ERR! not ok
```

The issue gets resolved when I update package.json with the latest dependencies (based on `ncu -a` (npm-check-updates)).